### PR TITLE
Style changes

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -233,8 +233,7 @@ header.sticky ul li a{
 
 .work .content .workBx img:hover{
     max-width: 100%;
-    border:#f8002f 1px solid;
-    margin-top: -5%;
+    box-shadow: 4px 4px 20px 4px #e87070;
 
 }
 


### PR DESCRIPTION
changed the border color of projects on hover, from red(which was a bit odd) to whitish red colored shadow which is decent with respect to white color headings. Also removed the margin top -5% from hover style attribute which was leading to touching of image and its heading.
### **BEFORE**
![before](https://user-images.githubusercontent.com/54476451/95161223-33da6c80-07c0-11eb-8396-6a556e9a0cae.PNG)
### **AFTER**
![after](https://user-images.githubusercontent.com/54476451/95161263-4e144a80-07c0-11eb-8afc-0722546307a4.PNG)
